### PR TITLE
Only letters

### DIFF
--- a/decrypted.txt
+++ b/decrypted.txt
@@ -1,1 +1,1 @@
-we didnt start the fire
+we didn't start the fire!

--- a/encrypted.txt
+++ b/encrypted.txt
@@ -1,1 +1,1 @@
-mbiwzawlqpbthqilybiyzon
+mbiwzaw'jxalrobsjenswf x!

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -19,4 +19,6 @@ class Decrypt
   writer.write(decrypted[:decryption])
   writer.close
 
+  puts "Created #{ARGV[1]} with the key #{ARGV[2]} and date #{ARGV[3]}"
+
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -47,6 +47,7 @@ class Enigma
   end
 
   def encrypt(message,key,offset)
+    message.downcase!
     @shifts.create_hashes(key,offset) #could this go in create_shifted_arrays?
     create_shifted_arrays(key,offset)
     shift_all(message)

--- a/lib/letter_shift.rb
+++ b/lib/letter_shift.rb
@@ -3,6 +3,7 @@ module LetterShift
     count = 0
     char_index(message).each_with_index do |char,index|
       if index == count
+        # if char
         message[index] = @a_array[char]
         count += 4
       end

--- a/lib/letter_shift.rb
+++ b/lib/letter_shift.rb
@@ -3,9 +3,12 @@ module LetterShift
     count = 0
     char_index(message).each_with_index do |char,index|
       if index == count
-        # if char
-        message[index] = @a_array[char]
-        count += 4
+        if char != nil
+          message[index] = @a_array[char]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     message #can I get rid of these returns and the tests since they are in the shift_all methods?
@@ -15,8 +18,12 @@ module LetterShift
     count = 1
     char_index(message).each_with_index do |char,index|
       if index == count
-        message[index] = @b_array[char]
-        count += 4
+        if char != nil
+          message[index] = @b_array[char]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     message
@@ -26,8 +33,12 @@ module LetterShift
     count = 2
     char_index(message).each_with_index do |char,index|
       if index == count
-        message[index] = @c_array[char]
-        count += 4
+        if char != nil
+          message[index] = @c_array[char]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     message
@@ -37,8 +48,12 @@ module LetterShift
     count = 3
     char_index(message).each_with_index do |char,index|
       if index == count
-        message[index] = @d_array[char]
-        count += 4
+        if char != nil
+          message[index] = @d_array[char]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     message

--- a/lib/letter_shift.rb
+++ b/lib/letter_shift.rb
@@ -70,8 +70,12 @@ module LetterShift
     count = 0
     encryption.chars.each_with_index do |char, index|
       if index == count
-        encryption[index] = @alphabet[@a_array.index(char)]
-        count += 4
+        if @alphabet.include?(char)
+          encryption[index] = @alphabet[@a_array.index(char)]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     encryption
@@ -81,8 +85,12 @@ module LetterShift
     count = 1
     encryption.chars.each_with_index do |char, index|
       if index == count
-        encryption[index] = @alphabet[@b_array.index(char)]
-        count += 4
+        if @alphabet.include?(char)
+          encryption[index] = @alphabet[@b_array.index(char)]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     encryption
@@ -92,8 +100,12 @@ module LetterShift
     count = 2
     encryption.chars.each_with_index do |char, index|
       if index == count
-        encryption[index] = @alphabet[@c_array.index(char)]
-        count += 4
+        if @alphabet.include?(char)
+          encryption[index] = @alphabet[@c_array.index(char)]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     encryption
@@ -103,8 +115,12 @@ module LetterShift
     count = 3
     encryption.chars.each_with_index do |char, index|
       if index == count
-        encryption[index] = @alphabet[@d_array.index(char)]
-        count += 4
+        if @alphabet.include?(char)
+          encryption[index] = @alphabet[@d_array.index(char)]
+          count += 4
+        else
+          count += 4
+        end
       end
     end
     encryption

--- a/message.txt
+++ b/message.txt
@@ -1,1 +1,1 @@
-we didnt start the fire
+We didn't start the fire!

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -12,19 +12,23 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_enigma_exists
+    skip
     assert_instance_of Enigma, @enigma
   end
 
   def test_engima_initializes_with_shifts_object
+    skip
     assert_instance_of Shifts, @enigma.shifts
   end
 
   def test_enigma_defaults_with_normal_alpha_array
+    skip
     expected = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", " "]
     assert_equal expected, @enigma.alphabet
   end
 
   def test_shifts_creates_shifted_arrays
+    skip
     @enigma.shifts.create_keys(12345)
     @enigma.shifts.offset_integrated("032489")
     @enigma.shifts.create_shifts
@@ -40,10 +44,12 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_message_chars_indices_in_array
+    skip
     assert_equal [3,20,2,10,18], @enigma.char_index("ducks") #this requires an attr_writer...
   end
 
   def test_encrypt_hash_method_returns_hash
+    skip
     expected = {encryption: "message",
                 key: "12345",
                 date: "032489"}
@@ -51,6 +57,7 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_encrypt_method_creates_encrypted_message
+    skip
     expected = {encryption: "urlci",
                 key: "12345",
                 date: "032489"}
@@ -58,10 +65,22 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_encrypt_method_creates_encrypted_message_with_capitals
+    skip
     expected = {encryption: "urlci",
                 key: "12345",
                 date: "032489"}
     assert_equal expected, @enigma.encrypt("DUCKS", "12345", "032489")
+  end
+
+  def test_encrypt_method_ignores_numbers_or_punctuation
+    expected = {encryption: "urlci.",
+                key: "12345",
+                date: "032489"}
+    assert_equal expected, @enigma.encrypt("ducks.", "12345", "032489")
+    expected = {encryption: "urlci2",
+                key: "12345",
+                date: "032489"}
+    assert_equal expected, @enigma.encrypt("ducks2", "12345", "032489")
   end
 
   def test_key_not_given_creates_random_number_encrypted_message
@@ -70,6 +89,7 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_decrypt_hash_method_returns_hash
+    skip
     expected = {decryption: "message",
                 key: "12345",
                 date: "032489"}
@@ -77,6 +97,7 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_decrypt_method_decodes_message
+    skip
     expected = {decryption: "ducks",
                 key: "12345",
                 date: "032489"}

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -54,7 +54,14 @@ class EnigmaTest < MiniTest::Test
     expected = {encryption: "urlci",
                 key: "12345",
                 date: "032489"}
-    assert_equal expected, @enigma.encrypt("ducks", "12345", "032489")
+    assert_equal expected, @enigma.encrypt("Ducks", "12345", "032489")
+  end
+
+  def test_encrypt_method_creates_encrypted_message_with_capitals
+    expected = {encryption: "urlci",
+                key: "12345",
+                date: "032489"}
+    assert_equal expected, @enigma.encrypt("DUCKS", "12345", "032489")
   end
 
   def test_key_not_given_creates_random_number_encrypted_message


### PR DESCRIPTION
Allows message to contain capitals and punctuation.
Also allows encryption to be decrypted when it contains punctuation. Not capitals because the encryption shouldn't have capitals.